### PR TITLE
Fix string macro parsing

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1278,7 +1278,7 @@
                        (loop `(macrocall ,macname ,startloc ,macstr
                                          ,(if (symbol? nxt)
                                               (string (take-token s))
-                              					      (take-token s))))
+                                              (take-token s))))
                        (loop `(macrocall ,macname ,startloc ,macstr))))
                  ex))
             (else ex))))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1272,7 +1272,7 @@
                                        (parse-raw-literal s t)))
                         (nxt (peek-token s))
                         (macname (macroify-name ex (macsuffix t))))
-                   (if (and (symbol? nxt) (not (operator? nxt))
+                   (if (and (or (symbol? nxt) (number? nxt)) (not (operator? nxt))
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1276,7 +1276,9 @@
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr
-                                         ,(string (take-token s))))
+                                         ,(if (symbol? nxt)
+                                              (string (take-token s))
+                              					      (take-token s))))
                        (loop `(macrocall ,macname ,startloc ,macstr))))
                  ex))
             (else ex))))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1272,7 +1272,7 @@
                                        (parse-raw-literal s t)))
                         (nxt (peek-token s))
                         (macname (macroify-name ex (macsuffix t))))
-                   (if (and (or (symbol? nxt) (number? nxt)) (not (operator? nxt))
+                   (if (and (or (symbol? nxt) (number? nxt) (large-number? nxt)) (not (operator? nxt))
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -61,7 +61,7 @@ macro test999_str(args...); args; end
     b""" == ("a\nb",)
 
 # make sure a trailing integer, not just a symbol, is allowed also
-@test test999"foo"123 == ("foo", "123")
+@test test999"foo"123 == ("foo", 123)
 
 # issue #5997
 @test_throws ParseError Meta.parse(": x")

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -60,6 +60,9 @@ macro test999_str(args...); args; end
     a
     b""" == ("a\nb",)
 
+# make sure a trailing integer, not just a symbol, is allowed also
+@test test999"foo"123 == ("foo", "123")
+
 # issue #5997
 @test_throws ParseError Meta.parse(": x")
 @test_throws ParseError Meta.parse("""begin


### PR DESCRIPTION
This allows for numbers to follow a string literal macro.
We'd like to use this for the `ShortStrings.jl` package (which will be used by Invenia).
Instead of having separate `ss3`, `ss7`, `ss15`, `ss31`, `ss63`, `ss127`, `ss255`, ... macros
(and really, anything in between), we want to be able to have a single `ss` macro, that optionally can take a max size parameter (otherwise, it would calculate the next size the string literal would fit in)
